### PR TITLE
Improve error messages, formatting, and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ pip install lookml-zenml
 To convert a entire project run the following command from your command line interface after installing the package. Note: make sure you specify your LookML project as the first argument, and you create a directory for the ZenML output.
 
 ```
-$ lookml_zenml convert ./my_lookml_project --out-directory ./my_new_zenml_project
+$ lookml_zenml convert ./my_lookml_project --out_directory ./my_new_zenml_project
 ```
 
 This is the standard way to convert a LookML project. This will convert dashboards, views, and models into the ZenML equivalent.
@@ -23,17 +23,17 @@ This is the standard way to convert a LookML project. This will convert dashboar
 You can also use this library to convert objects on a one-off basis. This is not as robust as converting the whole project due to loss of information for the dashboards and logic about joins in found in the explores that we add to the views. 
 
 
-To convert a model run the following command. Note: if you specify `--out-directory` the library will write a yml file to that directory, otherwise it will return the converted code to stdout.
+To convert a model run the following command. Note: if you specify `--out_directory` the library will write a yml file to that directory, otherwise it will return the converted code to stdout.
 
 ```
-$ lookml_zenml model ./my_lookml_project/my_model.model.lkml --out-directory ./my_new_dir
+$ lookml_zenml model ./my_lookml_project/my_model.model.lkml --out_directory ./my_new_dir
 ```
 
 
-To convert a view run the following command. Note: if you specify `--out-directory` the library will write a yml file to that directory, otherwise it will return the converted code to stdout.
+To convert a view run the following command. Note: if you specify `--out_directory` the library will write a yml file to that directory, otherwise it will return the converted code to stdout.
 
 ```
-$ lookml_zenml view ./my_lookml_project/my_view.view.lkml --out-directory ./my_new_dir
+$ lookml_zenml view ./my_lookml_project/my_view.view.lkml --out_directory ./my_new_dir
 ```
 
 To convert a dashboard run this command. Note: for dashboards the directory is required. If you do not have the directory of lookml files, you can point to an empty directory and the conversion will run, but will put all metrics on a dashboard into the `slice_by` heading because it will be unable to determine the field type of the fields. You'll then have to correct those manually.

--- a/lookml_zenml/lookml_project.py
+++ b/lookml_zenml/lookml_project.py
@@ -450,7 +450,7 @@ class LookMLProject:
                 if self.is_lookml_dashboard_file(file):
                     lookml_file = os.path.join(root, file)
                     with open(lookml_file) as f:
-                        lookml_dict = yaml.safe_load(f)
+                        lookml_dict = yaml.load(f)
                     lookml["dashboards"].extend(lookml_dict)
         return lookml
 


### PR DESCRIPTION
In this PR there are changes for

1. Fixing the README instructions. The correct flag should be `--out_directory` not `--out-directory`
2. using `ruamel.yaml` to format the views that are created with a default sort order and add indents for yaml lists for improved readability. This package is already a project dependency.
3. Add in default `timeframes` when `type: time` and `field_type: dimension_group` and the LookML field does not specify any timeframe.
4. Add some informative error messages for key's not existing in the LookML model (thus cannot be converted properly) and when the output directory does not exist.